### PR TITLE
Fix error when unloading plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,10 @@ npm run build
 ```
 Then restart obsidian and enable the plugin.
 
-#### NOTE:
-This plugin is currently sort of broken. On unload there's this error:
-```
-Plugin failure: obsidian-system-theme TypeError: Cannot read properties of undefined (reading 'offref')
-```
-so doing a full unload requires restarting obsidian. However it works fine when loaded, so I'm not going to spend any time trying to fix this atm. Its probably something to due with using remote: `require('electron').remote;`
+Tested on:
 
-Because of this I won't submit it to the official community plugins for now.
-
-Tested on Ubuntu 20.04
-
-GNOME Shell 3.36.9
+- Ubuntu 20.04, GNOME Shell 3.36.9
+- Arch Linux (linux 5.18.18-xanmod1-1), Sway 1.7
 
 ----
 

--- a/main.ts
+++ b/main.ts
@@ -6,7 +6,7 @@ export default class SystemThemePlugin extends Plugin {
 
 	async onload() {
 
-		let callback = () => {
+		const callback = () => {
 
 			if (nativeTheme.shouldUseDarkColors) {
 				// console.log('Dark mode active');
@@ -17,8 +17,8 @@ export default class SystemThemePlugin extends Plugin {
 			}
 		}
 
-		// Obsidian should automatically unregister this event on unload
-		this.registerEvent(nativeTheme.on('updated', callback));
+		const eventRef = nativeTheme.on('updated', callback);
+		this.register(() => nativeTheme.off('updated', callback));
 
 		callback();
 


### PR DESCRIPTION
I believe Obsidian's `registerEvent` only works with Obsidian events. Changed to registering a callback and manually removing the listener. 

I encourage you to submit this as a community plugin, I'm sure many others will find it useful!